### PR TITLE
GHC 7.4

### DIFF
--- a/network-fancy.cabal
+++ b/network-fancy.cabal
@@ -20,7 +20,7 @@ Library
     Exposed-modules:     Network.Fancy
     C-Sources:           cbits.c
     GHC-Options:         -Wall
-    Extensions:          TypeSynonymInstances, ForeignFunctionInterface, CPP, DeriveDataTypeable
+    Extensions:          TypeSynonymInstances, ForeignFunctionInterface, CPP, DeriveDataTypeable, FlexibleInstances
     if os(windows) {
       CPP-Options:       -DWINDOWS=WINDOWS -DCALLCONV=stdcall -DSAFE_ON_WIN=safe
       CC-Options:        -DWINDOWS=WINDOWS -DCALLCONV=stdcall -DSAFE_ON_WIN=safe


### PR DESCRIPTION
As it is now on hackage, network-fancy doesn't compile with GHC 7.4.x. This very simple patch fixes it.
