### PR TITLE
Compatibility with GHC 7.8

### DIFF
--- a/Network/Fancy.hsc
+++ b/Network/Fancy.hsc
@@ -23,7 +23,7 @@ import qualified Data.ByteString.Unsafe as B
 import qualified Data.ByteString.Lazy  as L
 import Data.List(intercalate)
 import Data.Typeable(Typeable)
-import Foreign
+import Foreign hiding (unsafeForeignPtrToPtr)
 import Foreign.C
 import Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
 import Numeric(showHex)


### PR DESCRIPTION
Hi,

The `Foreign` module of 7.8 no longer exports `unsafeForeignPtrToPtr`; it is hidden away in `Foreign.ForeignPtr.Unsafe`.  There was a warning in 7.6.3, but as of 7.8 it's gone.  This is a pretty straightforward fix/patch to maintain compatibility with both 7.6.3 and 7.8.
