### PR TITLE
Fixed build on OS X

### DIFF
--- a/Network/Fancy/Error.hs
+++ b/Network/Fancy/Error.hs
@@ -64,7 +64,7 @@ throwNetworkException :: Socket -> String -> Errno -> IO any
 throwNetworkException sock desc err = throwIO $! SocketException desc sock err
 
 
-#ifdef LINUX
+#ifdef HAVE_STRERROR_R
 strerror :: Errno -> String
 strerror (Errno val) = unsafePerformIO $
   allocaArray 512 $ \buffer -> do

--- a/network-fancy.cabal
+++ b/network-fancy.cabal
@@ -34,8 +34,9 @@ library
             exposed: True
             buildable: True
             extra-libraries: socket
+        if os(linux) || os(darwin)
+            cpp-options: -DHAVE_STRERROR_R=1
         if os(linux)
-            cpp-options: -DLINUX=LINUX
             extra-libraries: pthread
         exposed: True
         buildable: True


### PR DESCRIPTION
Building Fancy/Error.hs on OS X would fail with

Network/Fancy/Error.hs:77:12:
    No instance for (Show Errno) arising from a use of ‘show’
    In the expression: show
    In an equation for ‘strerror’: strerror = show

The reason for this is that the LINUX define is not set on OS X, hence
the 'strerror = show' definition is used - which doesn't compile,
because there is no 'Show' instance for Errno.

Instead of adding a 'DARWIN' operating system check or the like I
decided to change the check slightly so that instead of checking for an
operating system, the code checks for a particular feature. In this
case: the existence of the strerr_r function. The .cabal file is
adjusted accordingly such that HAVE_STRERR_R is true for OS X or Linux
builds.
